### PR TITLE
Implement model registry for training pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@ data/raw/
 data/processed/
 data/labels/
 reports/figures/
-models/
+/models/
 mlruns/
 notebooks/.ipynb_checkpoints/
 .eggs/

--- a/src/fosm_mlops/models/__init__.py
+++ b/src/fosm_mlops/models/__init__.py
@@ -1,0 +1,14 @@
+"""Model abstractions and utilities for the FOSM project."""
+
+from . import registry, utils
+from .anomaly import AnomalyModelConfig, BaseAnomalyModel
+from .classical import ClassicalModel, ClassicalModelConfig
+
+__all__ = [
+    "AnomalyModelConfig",
+    "BaseAnomalyModel",
+    "ClassicalModel",
+    "ClassicalModelConfig",
+    "registry",
+    "utils",
+]

--- a/src/fosm_mlops/models/anomaly.py
+++ b/src/fosm_mlops/models/anomaly.py
@@ -1,0 +1,92 @@
+"""Lightweight anomaly detection primitives."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from os import PathLike
+from typing import Any
+
+import joblib
+import numpy as np
+
+from .utils import persist_model
+
+
+@dataclass(slots=True)
+class AnomalyModelConfig:
+    """Configuration for anomaly detectors."""
+
+    name: str
+    params: dict[str, Any] = field(default_factory=dict)
+
+
+class _ZScoreModel:
+    """Simple z-score based anomaly scoring."""
+
+    def __init__(self, **_: Any) -> None:
+        self.mean_: np.ndarray | None = None
+        self.std_: np.ndarray | None = None
+
+    def fit(self, x: np.ndarray) -> None:
+        self.mean_ = np.mean(x, axis=0)
+        self.std_ = np.std(x, axis=0) + 1e-8
+
+    def predict_scores(self, x: np.ndarray) -> np.ndarray:
+        if self.mean_ is None or self.std_ is None:
+            msg = "Model must be fitted before calling predict_scores."
+            raise RuntimeError(msg)
+        z = np.abs((x - self.mean_) / self.std_)
+        return np.max(z, axis=1)
+
+    def save(self, path: str | PathLike[str]) -> None:
+        persist_model(self, path)
+
+
+class BaseAnomalyModel:
+    """Unified interface for anomaly detection models."""
+
+    def __init__(self, config: AnomalyModelConfig) -> None:
+        self.config = config
+        self.model = self._build_model(config)
+
+    @staticmethod
+    def _build_model(config: AnomalyModelConfig) -> Any:
+        name = config.name.split("/", maxsplit=1)[-1]
+        if name == "zscore":
+            return _ZScoreModel(**config.params)
+        if name == "isolation_forest":
+            from sklearn.ensemble import IsolationForest
+
+            return IsolationForest(**config.params)
+        if name == "lof":
+            from sklearn.neighbors import LocalOutlierFactor
+
+            return LocalOutlierFactor(novelty=True, **config.params)
+        msg = f"Unsupported anomaly model: {config.name}"
+        raise ValueError(msg)
+
+    def fit(self, x: np.ndarray) -> None:
+        self.model.fit(x)
+
+    def predict_scores(self, x: np.ndarray) -> np.ndarray:
+        if hasattr(self.model, "predict_scores"):
+            return self.model.predict_scores(x)  # type: ignore[return-value]
+        scores = self.model.decision_function(x)
+        if scores.ndim == 1:
+            return scores
+        return scores.squeeze()
+
+    def predict(self, x: np.ndarray, threshold: float = 0.0) -> np.ndarray:
+        scores = self.predict_scores(x)
+        return (scores > threshold).astype(int)
+
+    def save(self, path: str | PathLike[str]) -> None:
+        persist_model(self.model, path)
+
+    @classmethod
+    def load(cls, path: str | PathLike[str]) -> BaseAnomalyModel:
+        model = joblib.load(path)
+        instance = object.__new__(cls)
+        instance.config = AnomalyModelConfig(name="loaded")
+        instance.model = model
+        return instance

--- a/src/fosm_mlops/models/classical.py
+++ b/src/fosm_mlops/models/classical.py
@@ -1,0 +1,114 @@
+"""Classical supervised learning models."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from os import PathLike
+from typing import Any
+
+import numpy as np
+from imblearn.over_sampling import SMOTE, RandomOverSampler
+from sklearn.linear_model import LogisticRegression
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import StandardScaler
+
+from .utils import persist_model
+
+try:  # pragma: no cover - optional dependency imports
+    from sklearn.ensemble import RandomForestClassifier
+except ImportError as exc:  # pragma: no cover
+    raise ImportError("scikit-learn is required for classical models") from exc
+
+try:  # pragma: no cover
+    from xgboost import XGBClassifier
+except Exception:  # pragma: no cover
+    XGBClassifier = None  # type: ignore[assignment]
+
+try:  # pragma: no cover
+    from lightgbm import LGBMClassifier
+except Exception:  # pragma: no cover
+    LGBMClassifier = None  # type: ignore[assignment]
+
+
+@dataclass(slots=True)
+class ClassicalModelConfig:
+    """Configuration for classical classifiers."""
+
+    name: str
+    params: dict[str, Any] = field(default_factory=dict)
+    oversample: str | None = None
+
+
+class ClassicalModel:
+    """Wrapper around scikit-learn style classifiers with optional oversampling."""
+
+    def __init__(self, config: ClassicalModelConfig) -> None:
+        self.config = config
+        self.model = self._build_model(config)
+        self._oversampler = self._build_sampler(config.oversample)
+
+    @staticmethod
+    def _build_sampler(name: str | None) -> Any | None:
+        if name is None:
+            return None
+        name = name.lower()
+        if name == "smote":
+            return SMOTE()
+        if name == "random":
+            return RandomOverSampler()
+        msg = f"Unsupported oversampler: {name}"
+        raise ValueError(msg)
+
+    @staticmethod
+    def _build_model(config: ClassicalModelConfig) -> Any:
+        name = config.name.split("/", maxsplit=1)[-1]
+        params = {**config.params}
+        if name == "logistic_regression":
+            estimator = LogisticRegression(**params)
+            return Pipeline([
+                ("scaler", StandardScaler()),
+                ("model", estimator),
+            ])
+        if name == "random_forest":
+            return RandomForestClassifier(**params)
+        if name == "xgboost":
+            if XGBClassifier is None:
+                msg = "xgboost is not installed."
+                raise ImportError(msg)
+            default_params = {"use_label_encoder": False, "eval_metric": "logloss"}
+            default_params.update(params)
+            return XGBClassifier(**default_params)
+        if name == "lightgbm":
+            if LGBMClassifier is None:
+                msg = "lightgbm is not installed."
+                raise ImportError(msg)
+            return LGBMClassifier(**params)
+        msg = f"Unsupported classical model: {config.name}"
+        raise ValueError(msg)
+
+    def fit(self, x: np.ndarray, y: np.ndarray) -> None:
+        if self._oversampler is not None:
+            x, y = self._oversampler.fit_resample(x, y)
+        self.model.fit(x, y)
+
+    def predict(self, x: np.ndarray) -> np.ndarray:
+        return self.model.predict(x)
+
+    def predict_proba(self, x: np.ndarray) -> np.ndarray:
+        if not hasattr(self.model, "predict_proba"):
+            msg = "Underlying model does not support predict_proba"
+            raise AttributeError(msg)
+        return self.model.predict_proba(x)
+
+    def save(self, path: PathLike[str] | str) -> None:
+        persist_model(self.model, path)
+
+    @classmethod
+    def load(cls, path: PathLike[str] | str) -> ClassicalModel:
+        from .utils import load_model
+
+        model = load_model(path)
+        instance = cls(ClassicalModelConfig(name="loaded"))
+        instance.model = model
+        instance._oversampler = None
+        return instance

--- a/src/fosm_mlops/models/registry.py
+++ b/src/fosm_mlops/models/registry.py
@@ -1,0 +1,35 @@
+"""Factory helpers to instantiate models from config names."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .anomaly import AnomalyModelConfig, BaseAnomalyModel
+from .classical import ClassicalModel, ClassicalModelConfig
+
+
+def get_model(name: str, **kwargs: Any) -> Any:
+    """Instantiate a model by its registry ``name``.
+
+    Parameters
+    ----------
+    name:
+        Registry path such as ``"classical/random_forest"`` or ``"anomaly/zscore"``.
+    **kwargs:
+        Additional keyword arguments forwarded to the underlying config.
+    """
+
+    if name.startswith("classical/"):
+        config = ClassicalModelConfig(name=name, **kwargs)
+        return ClassicalModel(config)
+    if name.startswith("anomaly/"):
+        config = AnomalyModelConfig(name=name, **kwargs)
+        return BaseAnomalyModel(config)
+    if name.startswith("deep/"):
+        msg = (
+            "Deep learning models are not implemented in this lightweight runtime. "
+            "Please integrate a TensorFlow/PyTorch implementation and update the registry."
+        )
+        raise NotImplementedError(msg)
+    msg = f"Unknown model type for name: {name}"
+    raise ValueError(msg)

--- a/src/fosm_mlops/models/utils.py
+++ b/src/fosm_mlops/models/utils.py
@@ -1,0 +1,140 @@
+"""Model utility helpers used across training and evaluation."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from pathlib import Path
+
+import joblib
+import matplotlib.pyplot as plt
+import numpy as np
+from sklearn import metrics
+
+
+def persist_model(model: object, path: Path | str) -> None:
+    """Serialise a fitted model to disk."""
+
+    dest = Path(path)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    joblib.dump(model, dest)
+
+
+def load_model(path: Path | str) -> object:
+    """Load a model persisted with :func:`persist_model`."""
+
+    return joblib.load(path)
+
+
+def tune_threshold(
+    y_true: Iterable[int] | np.ndarray,
+    scores: Iterable[float] | np.ndarray,
+    *,
+    metric: str = "f1",
+    thresholds: Iterable[float] | None = None,
+) -> tuple[float, float]:
+    """Search for the best probability threshold."""
+
+    if thresholds is None:
+        thresholds = np.linspace(0.01, 0.99, 99)
+    y_true_arr = np.asarray(y_true)
+    score_arr = np.asarray(scores)
+    best_threshold = 0.5
+    best_score = -np.inf
+    for threshold in thresholds:
+        y_pred = (score_arr >= threshold).astype(int)
+        current_score = _threshold_metric(metric, y_true_arr, y_pred, score_arr)
+        if current_score > best_score:
+            best_score = current_score
+            best_threshold = float(threshold)
+    return best_threshold, float(best_score)
+
+
+def _threshold_metric(
+    metric: str, y_true: np.ndarray, y_pred: np.ndarray, scores: np.ndarray
+) -> float:
+    metric = metric.lower()
+    if metric == "f1":
+        return metrics.f1_score(y_true, y_pred, zero_division=0)
+    if metric == "precision":
+        return metrics.precision_score(y_true, y_pred, zero_division=0)
+    if metric == "recall":
+        return metrics.recall_score(y_true, y_pred, zero_division=0)
+    if metric == "roc_auc":
+        return metrics.roc_auc_score(y_true, scores)
+    if metric == "pr_auc":
+        return metrics.average_precision_score(y_true, scores)
+    msg = f"Unsupported threshold metric: {metric}"
+    raise ValueError(msg)
+
+
+def classification_metrics(
+    y_true: Iterable[int] | np.ndarray,
+    scores: Iterable[float] | np.ndarray,
+    *,
+    threshold: float = 0.5,
+) -> dict[str, float]:
+    """Compute a suite of classification metrics."""
+
+    y_true_arr = np.asarray(y_true)
+    scores_arr = np.asarray(scores)
+    y_pred = (scores_arr >= threshold).astype(int)
+    metrics_dict = {
+        "accuracy": metrics.accuracy_score(y_true_arr, y_pred),
+        "precision": metrics.precision_score(
+            y_true_arr, y_pred, zero_division=0
+        ),
+        "recall": metrics.recall_score(y_true_arr, y_pred, zero_division=0),
+        "f1": metrics.f1_score(y_true_arr, y_pred, zero_division=0),
+        "roc_auc": metrics.roc_auc_score(y_true_arr, scores_arr),
+        "pr_auc": metrics.average_precision_score(y_true_arr, scores_arr),
+    }
+    return metrics_dict
+
+
+def save_metrics_plots(
+    y_true: Iterable[int] | np.ndarray,
+    scores: Iterable[float] | np.ndarray,
+    output_dir: Path,
+    threshold: float,
+) -> None:
+    """Persist ROC, PR and confusion matrix plots to ``output_dir``."""
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    y_true_arr = np.asarray(y_true)
+    scores_arr = np.asarray(scores)
+    y_pred = (scores_arr >= threshold).astype(int)
+
+    fpr, tpr, _ = metrics.roc_curve(y_true_arr, scores_arr)
+    precision, recall, _ = metrics.precision_recall_curve(y_true_arr, scores_arr)
+    cm = metrics.confusion_matrix(y_true_arr, y_pred)
+
+    fig, ax = plt.subplots()
+    ax.plot(fpr, tpr, label=f"ROC AUC = {metrics.auc(fpr, tpr):.2f}")
+    ax.plot([0, 1], [0, 1], "k--", alpha=0.4)
+    ax.set_xlabel("False Positive Rate")
+    ax.set_ylabel("True Positive Rate")
+    ax.set_title("ROC Curve")
+    ax.legend(loc="lower right")
+    fig.savefig(output_dir / "roc_curve.png", dpi=150, bbox_inches="tight")
+    plt.close(fig)
+
+    fig, ax = plt.subplots()
+    ax.plot(recall, precision, label=f"PR AUC = {metrics.auc(recall, precision):.2f}")
+    ax.set_xlabel("Recall")
+    ax.set_ylabel("Precision")
+    ax.set_title("Precision-Recall Curve")
+    ax.legend(loc="lower left")
+    fig.savefig(output_dir / "pr_curve.png", dpi=150, bbox_inches="tight")
+    plt.close(fig)
+
+    fig, ax = plt.subplots()
+    im = ax.imshow(cm, interpolation="nearest", cmap=plt.cm.Blues)
+    fig.colorbar(im, ax=ax)
+    ax.set_title("Confusion Matrix")
+    ax.set_xlabel("Predicted label")
+    ax.set_ylabel("True label")
+    for i in range(cm.shape[0]):
+        for j in range(cm.shape[1]):
+            ax.text(j, i, f"{cm[i, j]}", ha="center", va="center", color="black")
+    fig.savefig(output_dir / "confusion_matrix.png", dpi=150, bbox_inches="tight")
+    plt.close(fig)


### PR DESCRIPTION
## Summary
- add a models package with classical classifiers, anomaly detection wrappers, and a registry used by the Hydra training pipeline
- provide shared utilities for persistence, threshold tuning, and metric visualisation to support training and evaluation workflows
- adjust .gitignore so source-controlled model code is not ignored by pattern intended for artifact directories

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d4504950c0832eb1808979c50c1151