### PR TITLE
Fix evaluation feature alignment

### DIFF
--- a/configs/eval/default.yaml
+++ b/configs/eval/default.yaml
@@ -1,4 +1,5 @@
 features_path: data/processed/features.parquet
 labels_path: data/labels/synthetic_labels.csv
 model_path: models/latest/model.joblib
+feature_columns_path: models/latest/feature_columns.json
 reports_dir: reports


### PR DESCRIPTION
## Summary
- load the saved feature column ordering during evaluation so the scaler receives the expected inputs
- align evaluation features with the training schema and drop sensor metadata before inference
- add a default feature_columns_path entry to the evaluation config for discoverability

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4d637cfdc832e9397cb7fa7ef6150