### PR TITLE
Ensure evaluation retains feature ordering metadata

### DIFF
--- a/scripts/evaluate.py
+++ b/scripts/evaluate.py
@@ -51,13 +51,17 @@ def _infer_model_features(model: object) -> list[str]:
     # first match.
     if hasattr(model, "named_steps"):
         for step in model.named_steps.values():
+            if hasattr(step, "feature_columns"):
+                feature_cols = step.feature_columns  # type: ignore[attr-defined]
+                if isinstance(feature_cols, (list | tuple)):
+                    return [str(col) for col in feature_cols]
             if hasattr(step, "feature_names_in_"):
                 return [str(col) for col in step.feature_names_in_]
 
     # Some custom wrappers might expose a ``feature_columns`` attribute.
     if hasattr(model, "feature_columns"):
-        feature_cols = getattr(model, "feature_columns")
-        if isinstance(feature_cols, (list, tuple)):
+        feature_cols = model.feature_columns  # type: ignore[attr-defined]
+        if isinstance(feature_cols, (list | tuple)):
             return [str(col) for col in feature_cols]
 
     return []

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -1,0 +1,45 @@
+"""Tests for evaluation utilities."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+import pandas as pd
+
+
+def _load_evaluate_module() -> ModuleType:
+    module_path = Path(__file__).resolve().parents[1] / "scripts" / "evaluate.py"
+    spec = importlib.util.spec_from_file_location("_evaluate", module_path)
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive guard
+        raise RuntimeError("Unable to load evaluate module")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class _DummyModel:
+    def __init__(self, feature_columns: list[str]):
+        self.feature_columns = feature_columns
+
+
+def test_prepare_feature_matrix_uses_model_metadata(tmp_path: Path) -> None:
+    cfg = {"feature_columns_path": tmp_path / "missing.json"}
+    data = pd.DataFrame(
+        {
+            "sensor_id": [1, 1],
+            "time_start": [0.0, 1.0],
+            "time_end": [0.5, 1.5],
+            "feature_a": [0.1, 0.2],
+            "feature_b": [0.3, 0.4],
+        }
+    )
+    data["target"] = 0
+
+    model = _DummyModel(["feature_b", "feature_c", "feature_a"])
+    evaluate_module = _load_evaluate_module()
+    matrix = evaluate_module._prepare_feature_matrix(cfg, data, model)
+
+    assert list(matrix.columns) == ["feature_b", "feature_c", "feature_a"]
+    assert (matrix["feature_c"] == 0.0).all()


### PR DESCRIPTION
## Summary
- attach the training feature column order directly to saved model objects so it is available even if the JSON artifact is missing
- let the evaluation helpers read feature metadata from pipeline steps and cover the behaviour with a focused unit test

## Testing
- pytest tests/test_evaluate.py
- ruff check scripts/evaluate.py src/fosm_mlops/pipelines/train_pipeline.py tests/test_evaluate.py

------
https://chatgpt.com/codex/tasks/task_e_68d4d8c3b99c832ebc5e697e636481fe